### PR TITLE
vaxxed command

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -96,6 +96,22 @@ export const handleCommand = async (command: Command, args: Args, username: stri
                     message.channel.send(msg);
                 })
             return;
+        case Command.Vaxxed:
+            // Generates a new botmessage with updated data (on the Github Actions *free* tier) every 6 hours using a
+            // simple Python script. See: https://github.com/lucasjcm/janule-botmessage-vaxxed
+            fetch('https://raw.githubusercontent.com/lucasjcm/janule-botmessage-vaxxed/master/botmessage.txt')
+                .then((response) => {
+                    return response.text();
+                })
+                .then((botmessage: string) => {
+                    message.channel.send(botmessage);
+                })
+                .catch(() => {
+                    const msg = 'An error happened and the issue has been logged somewhere (just in memory, and only ' +
+                        'until it is garbage collected). Fuck you.';
+                    message.channel.send(msg);
+                })
+            return;
         case Command.DeleteMeme:
             if (args.length > 0) {
                 const memeToDelete = args.join(' ');

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -7,6 +7,7 @@ export const COMMAND_STRING_PARSE_MAP = {
     addmeme: Command.AddMeme,
     addedge: Command.AddEdge,
     covid: Command.Covid,
+    vaxxed: Command.Vaxxed,
     addstrain: Command.AddStrain,
     deletememe: Command.DeleteMeme,
     deletestrain: Command.DeleteStrain,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export enum Command {
     AddMeme,
     AddEdge,
     Covid,
+    Vaxxed,
     AddStrain,
     DeleteMeme,
     DeleteStrain,


### PR DESCRIPTION
`!j vaxxed`

outputs

`🇺🇸 2021-01-02: 4,225,756 total vaxxed | https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/vaccinations/vaccinations.csv`

source: https://github.com/lucasjcm/janule-botmessage-vaxxed/blob/main/botmessage.txt

it's like `!j covid` ... if we make one more command like this we could probably generalize that functionality somehow in code. but for now copy paste ye